### PR TITLE
unicode mapping for ascii control chars, utf8 control chars to symbols; fixed output formatting

### DIFF
--- a/main.go
+++ b/main.go
@@ -260,7 +260,7 @@ var encodings = []encoding{
 		ByteLength:  8,
 		Separator:   ``,
 		MaxWidth:    8,
-		Desc:        `UTF-8 encoded text. Replaces the following characters with their unicode equivalents: \\n, \\t, \\r, \\v, \\f, \\b, \\a, \\x1b. Uses a global variable to rollover between chunks.`,
+		Desc:        `UTF-8 encoded text. Replaces control characters with unicode symbol equivalents (mostly). Uses a global variable to rollover between chunks.`,
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -319,15 +319,19 @@ func processLine(chunk []byte, idx int) {
 }
 func main() {
 	if bufferSize%8 != 0 {
-		fmt.Println("width must be divisible by 8")
+		fmt.Fprintln(os.Stderr, "width must be divisible by 8")
+		// cli error format
+
 		return
 	}
 	reader := bufio.NewReader(os.Stdin)
+	// read full buffer
+
 	idx := 0
 	printHeader(enabledEncodings)
 	for {
 		chunk := make([]byte, bufferSize)
-		n, err := reader.Read(chunk)
+		n, err := io.ReadFull(reader, chunk)
 		if err != nil {
 			if err == io.EOF {
 				break


### PR DESCRIPTION
1. mapped control chars in ascii to unicode symbols 
2. tried to get utf8 control chars to map to their correct symbol representations when possible
3. fixed output formatting spacing when lower than full number of bytes available.
4. fixed error message formatting
