### PR TITLE
Fix errors and add rainbow colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ sudo mv byteviewer /usr/local/bin
 Simply read from any standard input and flag all the formats you want to display, like so:
 
 ```bash
-cat myfile | byteviewer -int32 -hex -uint8
+cat myfile | byteviewer -i32 -hex -u8
 
 uint8                           int32                 hex
 -----------------------------------------------------------------------
@@ -39,16 +39,16 @@ to read directly from a file.
 
 Supported formats (WIP):
 
-1. int8
-2. uint8
-3. int16
-4. uint16
-5. int32
-6. uint32
-7. float32
-8. int64
-9. uint64
-10. float64
+1. i8
+2. u8
+3. i16
+4. u16
+5. i32
+6. u32
+7. f32
+8. i64
+9. u64
+10. f64
 11. hex
 12. ascii
 13. utf8

--- a/main/encodings.go
+++ b/main/encodings.go
@@ -148,7 +148,7 @@ func (e *encoding) EncodingWidth(bytewidth int) int {
 
 var encodings = []encoding{
 	{
-		Name: "int8",
+		Name: "i8",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", int8(b[0])), len(b)
 		},
@@ -159,7 +159,7 @@ var encodings = []encoding{
 		Desc:       `Signed 8-bit integer`,
 	},
 	{
-		Name: "uint8",
+		Name: "u8",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", uint8(b[0])), len(b)
 		},
@@ -170,7 +170,7 @@ var encodings = []encoding{
 		Desc:       `Unsigned 8-bit integer`,
 	},
 	{
-		Name: "int16",
+		Name: "i16",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", int16(binary.LittleEndian.Uint16(b))), len(b)
 		},
@@ -181,7 +181,7 @@ var encodings = []encoding{
 		Desc:       `Signed 16-bit integer`,
 	},
 	{
-		Name: "uint16",
+		Name: "u16",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", binary.LittleEndian.Uint16(b)), len(b)
 		},
@@ -192,7 +192,7 @@ var encodings = []encoding{
 		Desc:       `Unsigned 16-bit integer`,
 	},
 	{
-		Name: "int32",
+		Name: "i32",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", int32(binary.LittleEndian.Uint32(b))), len(b)
 		},
@@ -203,7 +203,7 @@ var encodings = []encoding{
 		Desc:       `Signed 32-bit integer`,
 	},
 	{
-		Name: "uint32",
+		Name: "u32",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", binary.LittleEndian.Uint32(b)), len(b)
 		},
@@ -214,7 +214,7 @@ var encodings = []encoding{
 		Desc:       `Unsigned 32-bit integer`,
 	},
 	{
-		Name: "float32",
+		Name: "f32",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%12.6f", math.Float32frombits(binary.BigEndian.Uint32(b))), len(b)
 		},
@@ -225,7 +225,7 @@ var encodings = []encoding{
 		Desc:       `IEEE 754 single-precision binary floating-point format: sign bit, 8 bits exponent, 23 bits mantissa`,
 	},
 	{
-		Name: "int64",
+		Name: "i64",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", int64(binary.BigEndian.Uint64(b))), len(b)
 		},
@@ -236,7 +236,7 @@ var encodings = []encoding{
 		Desc:       `Signed 64-bit integer`,
 	},
 	{
-		Name: "uint64",
+		Name: "u64",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%d", binary.BigEndian.Uint64(b)), len(b)
 		},
@@ -247,7 +247,7 @@ var encodings = []encoding{
 		Desc:       `Unsigned 64-bit integer`,
 	},
 	{
-		Name: "float64",
+		Name: "f64",
 		EncoderFunc: func(b []byte) (string, int) {
 			return fmt.Sprintf("%12.6f", math.Float64frombits(binary.BigEndian.Uint64(b))), len(b)
 		},
@@ -267,7 +267,7 @@ var encodings = []encoding{
 		Desc:        `Hexadecimal encoding`,
 	},
 	{
-		Name:        "utf8hex",
+		Name:        "utf8h",
 		EncoderFunc: func(b []byte) (string, int) {
 			r, consumed := utf8GetRune(b)
 			if consumed > 0 {
@@ -283,7 +283,7 @@ var encodings = []encoding{
 		Desc:        `Unicode code points of UTF-8 encoded text. Hexadecimal.`,
 	},
 	{
-		Name:        "utf8int",
+		Name:        "utf8i",
 		EncoderFunc: func(b []byte) (string, int) {
 			r, consumed := utf8GetRune(b)
 			if consumed > 0 {

--- a/main/encodings.go
+++ b/main/encodings.go
@@ -216,7 +216,7 @@ var encodings = []encoding{
 	{
 		Name: "f32",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%12.6f", math.Float32frombits(binary.BigEndian.Uint32(b))), len(b)
+			return fmt.Sprintf("%12.6f", math.Float32frombits(binary.LittleEndian.Uint32(b))), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 4,
@@ -227,7 +227,7 @@ var encodings = []encoding{
 	{
 		Name: "i64",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%d", int64(binary.BigEndian.Uint64(b))), len(b)
+			return fmt.Sprintf("%d", int64(binary.LittleEndian.Uint64(b))), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 8,
@@ -238,7 +238,7 @@ var encodings = []encoding{
 	{
 		Name: "u64",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%d", binary.BigEndian.Uint64(b)), len(b)
+			return fmt.Sprintf("%d", binary.LittleEndian.Uint64(b)), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 8,
@@ -249,7 +249,7 @@ var encodings = []encoding{
 	{
 		Name: "f64",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%12.6f", math.Float64frombits(binary.BigEndian.Uint64(b))), len(b)
+			return fmt.Sprintf("%12.6f", math.Float64frombits(binary.LittleEndian.Uint64(b))), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 8,

--- a/main/encodings.go
+++ b/main/encodings.go
@@ -216,7 +216,7 @@ var encodings = []encoding{
 	{
 		Name: "f32",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%12.6f", math.Float32frombits(binary.LittleEndian.Uint32(b))), len(b)
+			return fmt.Sprintf("%.6g", math.Float32frombits(binary.LittleEndian.Uint32(b))), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 4,
@@ -249,7 +249,7 @@ var encodings = []encoding{
 	{
 		Name: "f64",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%12.6f", math.Float64frombits(binary.LittleEndian.Uint64(b))), len(b)
+			return fmt.Sprintf("%.6g", math.Float64frombits(binary.LittleEndian.Uint64(b))), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 8,

--- a/main/encodings.go
+++ b/main/encodings.go
@@ -216,7 +216,7 @@ var encodings = []encoding{
 	{
 		Name: "float32",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%12.6f\n", math.Float32frombits(binary.BigEndian.Uint32(b))), len(b)
+			return fmt.Sprintf("%12.6f", math.Float32frombits(binary.BigEndian.Uint32(b))), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 4,
@@ -249,7 +249,7 @@ var encodings = []encoding{
 	{
 		Name: "float64",
 		EncoderFunc: func(b []byte) (string, int) {
-			return fmt.Sprintf("%12.6f\n", math.Float64frombits(binary.BigEndian.Uint64(b))), len(b)
+			return fmt.Sprintf("%12.6f", math.Float64frombits(binary.BigEndian.Uint64(b))), len(b)
 		},
 		Enabled:    false,
 		ByteLength: 8,

--- a/main/encodings.go
+++ b/main/encodings.go
@@ -276,6 +276,6 @@ var encodings = []encoding{
 		ByteLength:  0,
 		Separator:   ``,
 		MaxWidth:    1,
-		Desc:        `UTF-8 encoded text. Replaces control characters with unicode symbol equivalents (mostly). Uses a global variable to rollover between chunks.`,
+		Desc:        `UTF-8 encoded text. Replaces control characters with unicode symbol equivalents (mostly).`,
 	},
 }

--- a/main/encodings.go
+++ b/main/encodings.go
@@ -47,7 +47,8 @@ func (e *encoding) Encode(chunk []byte) string {
 			encoded = fmt.Sprintf("%*s%s", e.MaxWidth - encodedLen, "", encoded)
 		}
 		if (enableColors) {
-			encoded = "\x1b[1;" + termColors[(e.total + start) % len(termColors)] + "m" + encoded
+			colorIndex := ((e.total + start) / colorWidth) % len(termColors)
+			encoded = "\x1b[1;" + termColors[colorIndex] + "m" + encoded
 		}
 		start += consumed
 		output = append(output, encoded)

--- a/main/main.go
+++ b/main/main.go
@@ -93,9 +93,6 @@ ReadLoop:
 		chunk := make([]byte, bufferSize)
 		n, err := io.ReadFull(reader, chunk)
 
-		// Only process the bytes that were actually read
-		processLine(chunk[:n], idx)
-
 		if err != nil {
 			if err == io.EOF || err == io.ErrUnexpectedEOF {
 				processLine(chunk[:n], idx)
@@ -104,6 +101,10 @@ ReadLoop:
 			fmt.Fprintln(os.Stderr, "error reading input:", err)
 			return
 		}
+
+		// Only process the bytes that were actually read
+		processLine(chunk[:n], idx)
+
 		if idx >= numLines && numLines != 0 {
 			break
 		}

--- a/main/main.go
+++ b/main/main.go
@@ -14,6 +14,7 @@ var (
 	inputFile        string
 	numLines         int
 	enableColors     bool
+	colorWidth     	 int
 )
 
 func init() {
@@ -22,6 +23,7 @@ func init() {
 	}
 	flag.StringVar(&inputFile, "file", "", "The file to read input from (stdin by default)")
 	flag.BoolVar(&enableColors, "color", false, "Decorate output with rainbow colors")
+	flag.IntVar(&colorWidth, "colorWidth", 1, "Width in bytes of each color")
 	flag.IntVar(&bufferSize, "width", 8, "How many bytes to print per line")
 	flag.IntVar(&numLines, "n", 0, "How many lines to print")
 	flag.Parse()

--- a/main/main.go
+++ b/main/main.go
@@ -23,7 +23,7 @@ func init() {
 	}
 	flag.StringVar(&inputFile, "file", "", "The file to read input from (stdin by default)")
 	flag.BoolVar(&enableColors, "color", false, "Decorate output with rainbow colors")
-	flag.IntVar(&colorWidth, "colorWidth", 1, "Width in bytes of each color")
+	flag.IntVar(&colorWidth, "colorWidth", 2, "Width in bytes of each color")
 	flag.IntVar(&bufferSize, "width", 8, "How many bytes to print per line")
 	flag.IntVar(&numLines, "n", 0, "How many lines to print")
 	flag.Parse()

--- a/main/main.go
+++ b/main/main.go
@@ -13,6 +13,7 @@ var (
 	bufferSize       int
 	inputFile        string
 	numLines         int
+	enableColors     bool
 )
 
 func init() {
@@ -20,8 +21,8 @@ func init() {
 		flag.BoolVar(&encodings[i].Enabled, e.Name, false, e.Desc)
 	}
 	flag.StringVar(&inputFile, "file", "", "The file to read input from (stdin by default)")
+	flag.BoolVar(&enableColors, "color", false, "Decorate output with rainbow colors")
 	flag.IntVar(&bufferSize, "width", 8, "How many bytes to print per line")
-
 	flag.IntVar(&numLines, "n", 0, "How many lines to print")
 	flag.Parse()
 
@@ -59,6 +60,9 @@ func processLine(chunk []byte, idx int) {
 	var ln string
 	for i := 0; i < len(enabledEncodings); i++ {
 		ln += enabledEncodings[i].Encode(chunk) + "   "
+	}
+	if (enableColors) {
+		ln += "\x1b[0m"
 	}
 	fmt.Fprintln(os.Stdout, ln)
 

--- a/main/main.go
+++ b/main/main.go
@@ -20,7 +20,7 @@ func init() {
 		flag.BoolVar(&encodings[i].Enabled, e.Name, false, e.Desc)
 	}
 	flag.StringVar(&inputFile, "file", "", "The file to read input from (stdin by default)")
-	flag.IntVar(&bufferSize, "width", 8, "How many bytes to print per line (must be multiple of 8)")
+	flag.IntVar(&bufferSize, "width", 8, "How many bytes to print per line")
 
 	flag.IntVar(&numLines, "n", 0, "How many lines to print")
 	flag.Parse()
@@ -43,7 +43,7 @@ func init() {
 func printHeader(enc []encoding) {
 	sepWidth := 0
 	for _, e := range enc {
-		stri := fmt.Sprintf("%-*s ", e.EncodingWidth(bufferSize), e.Name)
+		stri := fmt.Sprintf("%-*s ", e.EncodingWidth(bufferSize) + 2, e.Name)
 		sepWidth += len(stri)
 		fmt.Fprint(os.Stdout, stri)
 	}
@@ -58,18 +58,17 @@ func processLine(chunk []byte, idx int) {
 
 	var ln string
 	for i := 0; i < len(enabledEncodings); i++ {
-		ln += enabledEncodings[i].Encode(chunk) + " "
+		ln += enabledEncodings[i].Encode(chunk) + "   "
 	}
 	fmt.Fprintln(os.Stdout, ln)
 
 }
 func main() {
-	if bufferSize%8 != 0 {
-		fmt.Fprintln(os.Stderr, "width must be divisible by 8")
-		// cli error format
-
+	if bufferSize <= 0 {
+		fmt.Fprintln(os.Stderr, "width must be >0")
 		return
 	}
+
 
 	// Create a buffered reader
 	reader := bufio.NewReader(os.Stdin);


### PR DESCRIPTION
Fixes a previous error I introduced that caused the last line to be printed twice (sorry). Also removes the constraint that width must be multiple of 8, gets rid of the awkward global state that was needed for UTF-8 support, and adds an optional feature to display colored output. Each byte has a consistent color across all encodings, which makes it easier to match up the same byte:

![ss-20240322-1204](https://github.com/lizdotsh/byteviewer/assets/9331264/d69524aa-3c43-4e41-a11b-9e84174883b3)
